### PR TITLE
Change checkActivation to public to call on a template render

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -365,7 +365,7 @@ class Item
     /**
      * Activate the item if it's enabled in menu config and item's url matches the request URI
      */
-    protected function checkActivation()
+    public function checkActivation()
     {
         if ($this->menu->config->autoActivate && $this->currentUrlMatches()) {
             $this->activate();


### PR DESCRIPTION
Changed to make in render template check if a parent menu is active when they has a class to collapse

```
if($item->hasChildren()){
    $item->link->attr('class', 'accordion-toggle');
    $item->checkActivation();
}